### PR TITLE
Some performance improvements

### DIFF
--- a/RBush/RBush.Node.cs
+++ b/RBush/RBush.Node.cs
@@ -13,6 +13,7 @@ namespace RBush
 			internal Node(List<ISpatialData> items, int height)
 			{
 				this.Height = height;
+				this.IsLeaf = height == 1;
 				this.children = items;
 				ResetEnvelope();
 			}
@@ -44,7 +45,7 @@ namespace RBush
 
 			public IReadOnlyList<ISpatialData> Children => children;
 			public int Height { get; }
-			public bool IsLeaf => Height == 1;
+			public bool IsLeaf { get; }
 			public ref readonly Envelope Envelope => ref _envelope;
 		}
 	}

--- a/RBush/RBush.Node.cs
+++ b/RBush/RBush.Node.cs
@@ -13,7 +13,6 @@ namespace RBush
 			internal Node(List<ISpatialData> items, int height)
 			{
 				this.Height = height;
-				this.IsLeaf = height == 1;
 				this.children = items;
 				ResetEnvelope();
 			}
@@ -45,7 +44,7 @@ namespace RBush
 
 			public IReadOnlyList<ISpatialData> Children => children;
 			public int Height { get; }
-			public bool IsLeaf { get; }
+			public bool IsLeaf => Height == 1;
 			public ref readonly Envelope Envelope => ref _envelope;
 		}
 	}

--- a/RBush/RBush.Utilities.cs
+++ b/RBush/RBush.Utilities.cs
@@ -58,15 +58,21 @@ namespace RBush
 
 				if (item.IsLeaf)
 				{
-					foreach (var childItem in item.children)
-						if (childItem.Envelope.Intersects(boundingBox))
-							intersections.Add((T)childItem);
+					for (var index = 0; index < item.children.Count; index++)
+					{
+						var leafChildItem = item.children[index];
+						if (leafChildItem.Envelope.Intersects(boundingBox))
+							intersections.Add((T)leafChildItem);
+					}
 				}
 				else
 				{
-					foreach (var childItem in item.children)
-						if (childItem.Envelope.Intersects(boundingBox))
-							queue.Enqueue((Node)childItem);
+					for (var index = 0; index < item.children.Count; index++)
+					{
+						var childNode = item.children[index];
+						if (childNode.Envelope.Intersects(boundingBox))
+							queue.Enqueue((Node)childNode);
+					}
 				}
 			}
 

--- a/RBush/RBush.Utilities.cs
+++ b/RBush/RBush.Utilities.cs
@@ -55,21 +55,18 @@ namespace RBush
 			while (queue.Count != 0)
 			{
 				var item = queue.Dequeue();
-				for (var i = 0; i < item.children.Count; i++)
-				{
-					var childItem = item.children[i];
 
-					if (childItem.Envelope.Intersects(boundingBox))
-					{
-						if (item.IsLeaf)
-						{
+				if (item.IsLeaf)
+				{
+					foreach (var childItem in item.children)
+						if (childItem.Envelope.Intersects(boundingBox))
 							intersections.Add((T)childItem);
-						}
-						else
-						{
+				}
+				else
+				{
+					foreach (var childItem in item.children)
+						if (childItem.Envelope.Intersects(boundingBox))
 							queue.Enqueue((Node)childItem);
-						}
-					}
 				}
 			}
 

--- a/RBush/RBush.Utilities.cs
+++ b/RBush/RBush.Utilities.cs
@@ -55,17 +55,21 @@ namespace RBush
 			while (queue.Count != 0)
 			{
 				var item = queue.Dequeue();
-				if (item.IsLeaf)
+				for (var i = 0; i < item.children.Count; i++)
 				{
-					foreach (T leafChildItem in item.children.Cast<T>())
-						if (leafChildItem.Envelope.Intersects(boundingBox))
-							intersections.Add(leafChildItem);
-				}
-				else
-				{
-					foreach (var child in item.children.Cast<Node>())
-						if (child.Envelope.Intersects(boundingBox))
-							queue.Enqueue(child);
+					var childItem = item.children[i];
+
+					if (childItem.Envelope.Intersects(boundingBox))
+					{
+						if (item.IsLeaf)
+						{
+							intersections.Add((T)childItem);
+						}
+						else
+						{
+							queue.Enqueue((Node)childItem);
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
A performance improvement for `DoSearch` method.
* `foreach` changed to `for` to avoid using iterator
* Cast performed only in case an item is added to the intersection list or queue
* `IsLeaf` variable is calculated only once for each object

All unit tests have passed.